### PR TITLE
Unify edge naming for blur direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PDVariableBlur provides a variable blur effect for SwiftUI views on iOS and macO
 ### iOS
 
 ```swift
-VariableBlurView(direction: .top,
+VariableBlurView(edge: .top,
                  tintColor: UIColor.black.withAlphaComponent(0.3))
     .frame(height: 200)
 ```
@@ -23,12 +23,12 @@ VariableBlurContainer(blurRadius: 20,
 }
 ```
 
-### Direction
+### Edge
 
-`VariableBlurDirection` specifies from which edge the blur starts.
+`VariableBlurEdge` specifies from which edge the blur starts.
 
 ```swift
-public enum VariableBlurDirection {
+public enum VariableBlurEdge {
     case top      // blur starts at the top edge
     case bottom   // blur starts at the bottom edge
     case trailing // blur starts at the trailing edge

--- a/Sources/PDVariableBlur/PDVariableBlur.swift
+++ b/Sources/PDVariableBlur/PDVariableBlur.swift
@@ -3,7 +3,7 @@
 
 
 import SwiftUI
-public enum VariableBlurDirection {
+public enum VariableBlurEdge {
     /// Blur starts from the top edge and gradually clears toward the bottom.
     case top
     /// Blur starts from the bottom edge and gradually clears toward the top.
@@ -25,7 +25,7 @@ public struct VariableBlurView: UIViewRepresentable {
     
     public var maxBlurRadius: CGFloat = 20
     
-    public var direction: VariableBlurDirection = .top
+    public var edge: VariableBlurEdge = .top
     
     public var startOffset: CGFloat = 0
     
@@ -33,12 +33,12 @@ public struct VariableBlurView: UIViewRepresentable {
     public var tintStartOpacity: CGFloat?
     
     public init(maxBlurRadius: CGFloat = 20,
-                direction: VariableBlurDirection = .top,
+                edge: VariableBlurEdge = .top,
                 startOffset: CGFloat = 0,
                 tintColor: UIColor? = nil,
                 tintStartOpacity: CGFloat? = nil) {
         self.maxBlurRadius      = maxBlurRadius
-        self.direction          = direction
+        self.edge               = edge
         self.startOffset        = startOffset
         self.tintColor          = tintColor
         self.tintStartOpacity   = tintStartOpacity
@@ -46,7 +46,7 @@ public struct VariableBlurView: UIViewRepresentable {
     
     public func makeUIView(context: Context) -> VariableBlurUIView {
         VariableBlurUIView(maxBlurRadius: maxBlurRadius,
-                           direction: direction,
+                           edge: edge,
                            startOffset: startOffset,
                            tintColor: tintColor,
                            tintStartOpacity: tintStartOpacity)
@@ -60,7 +60,7 @@ open class VariableBlurUIView: UIVisualEffectView {
 
     // MARK: - Public Stored Properties
     public var maxBlurRadius: CGFloat          { didSet { refresh() } }
-    public var direction:      VariableBlurDirection { didSet { refresh() } }
+    public var edge:           VariableBlurEdge { didSet { refresh() } }
     /// 0.0〜1.0  (0 = 端から徐々にクリア、1 = ほぼ全域がブラー)
     public var startOffset:    CGFloat         { didSet { refresh() } }
     /// nil ならブラーのみ。色を指定すると同勾配でカラーオーバーレイを追加
@@ -72,12 +72,12 @@ open class VariableBlurUIView: UIVisualEffectView {
 
     // MARK: - Init
     public init(maxBlurRadius: CGFloat = 20,
-                direction: VariableBlurDirection = .top,
+                edge: VariableBlurEdge = .top,
                 startOffset: CGFloat = 0,
                 tintColor: UIColor? = nil,
                 tintStartOpacity: CGFloat? = nil) {
         self.maxBlurRadius = maxBlurRadius
-        self.direction     = direction
+        self.edge          = edge
         self.startOffset   = startOffset
         self.bluredTintColor     = tintColor
         self.tintStartOpacity    = tintStartOpacity
@@ -167,7 +167,7 @@ open class VariableBlurUIView: UIVisualEffectView {
     }
 
     private func setGradientPoints(for layer: CAGradientLayer) {
-        switch direction {
+        switch edge {
         case .top:
             layer.startPoint = CGPoint(x: 0.5, y: 0.0)
             layer.endPoint   = CGPoint(x: 0.5, y: 1.0)
@@ -191,7 +191,7 @@ open class VariableBlurUIView: UIVisualEffectView {
         filter.color0 = CIColor.black
         filter.color1 = CIColor.clear
 
-        switch direction {
+        switch edge {
         case .top:
             filter.point0 = CGPoint(x: 0, y: height)
             filter.point1 = CGPoint(x: 0, y: startOffset * height)
@@ -226,13 +226,13 @@ open class VariableBlurUIView: UIVisualEffectView {
         VStack{
             VariableBlurView(
                 maxBlurRadius:60,
-                direction: .top,
+                edge: .top,
                 tintColor: UIColor(Color.indigo)
             )
             .frame(height:150)
             Spacer()
             VariableBlurView(
-                direction: .bottom,
+                edge: .bottom,
                 tintColor: UIColor(Color.blue)
             )
             .frame(height:110)

--- a/Sources/PDVariableBlur/macOS.swift
+++ b/Sources/PDVariableBlur/macOS.swift
@@ -35,7 +35,7 @@ struct ContentView: View {
 #Preview{
     ContentView()
 }
-public enum BlurEdge {
+public enum VariableBlurEdge {
     case top      // ビュー上端側をぼかす
     case bottom   // ビュー下端側をぼかす
 }
@@ -45,14 +45,14 @@ public struct VariableBlurContainer<Content: View>: NSViewRepresentable {
     
     var blurRadius:  CGFloat
     var blurLength:  CGFloat
-    var edge: BlurEdge
+    var edge: VariableBlurEdge
     var padding: CGFloat = 0
     var isEnabled: Bool = true
     @ViewBuilder var content: () -> Content
     public init(
         blurRadius: CGFloat,
         blurLength:  CGFloat = 120,
-        edge:BlurEdge,
+        edge:VariableBlurEdge,
         padding: CGFloat,
         isEnabled:Bool = true,
         content: @escaping () -> Content
@@ -129,7 +129,7 @@ public final class FilterOverlayView: NSView {
 
     var blurRadius: CGFloat = 20   { didSet { updateFilter() } }
     var blurLength: CGFloat = 120  { didSet { updateFilter() } }
-    var edge: BlurEdge = .bottom   { didSet { updateFilter() } }
+    var edge: VariableBlurEdge = .bottom   { didSet { updateFilter() } }
     var padding: CGFloat = 0       { didSet { updateFilter() } }
 
     public override var wantsUpdateLayer: Bool { true }
@@ -198,7 +198,7 @@ public class FilterView: NSView {
     
     public var blurRadius: CGFloat = 50  { didSet { needsDisplay = true } }
     public var blurLength: CGFloat = 120 { didSet { needsDisplay = true } }
-    public var edge: BlurEdge     = .top { didSet { needsDisplay = true } }
+    public var edge: VariableBlurEdge     = .top { didSet { needsDisplay = true } }
     public var padding: CGFloat   = 0    { didSet { needsDisplay = true } }
     public var isEnabled: Bool = true    { didSet { needsDisplay = true } }
     


### PR DESCRIPTION
## Summary
- rename `VariableBlurDirection` enum to `VariableBlurEdge`
- update iOS `VariableBlurView` API to use `edge:` parameter
- rename macOS `BlurEdge` to `VariableBlurEdge`
- document new naming in README

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*