### PR TITLE
Add example executable target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,13 +14,18 @@ let package = Package(
         .library(
             name: "PDVariableBlur",
             targets: ["PDVariableBlur"]),
+        // Adding an executable product for the examples target allows Xcode
+        // to generate a scheme that includes Example.swift for previews.
+        .executable(
+            name: "Examples",
+            targets: ["Examples"]),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "PDVariableBlur"),
-        .target(
+        .executableTarget(
             name: "Examples",
             dependencies: ["PDVariableBlur"],
             path: "Examples"),


### PR DESCRIPTION
## Summary
- update `Package.swift` to include `Examples` as executable target

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684455bf68148325aa636bd23ddc2a00