### PR TITLE
Add update method for VariableBlurView

### DIFF
--- a/Sources/PDVariableBlur/PDVariableBlur+macOS.swift
+++ b/Sources/PDVariableBlur/PDVariableBlur+macOS.swift
@@ -70,17 +70,16 @@ public struct VariableBlurViewRepresentable: NSViewRepresentable {
 open class VariableBlurView: NSView {
 
     // MARK: Public Stored Properties
-    public var radius: CGFloat
-    public var edge: VariableBlurEdge
-    public var offset: CGFloat
-    public var bluredTintColor: NSColor?
+    private var radius: CGFloat
+    private var edge: VariableBlurEdge
+    private var offset: CGFloat
+    private var bluredTintColor: NSColor?
 
     // MARK: Private
     private let containerLayer = CALayer()
     private let backdropLayer : CALayer
     private var gradientLayer : CAGradientLayer?
-    var isBatchUpdating = false
-    public  var tintOpacity: CGFloat?
+    private  var tintOpacity: CGFloat?
 
     // MARK: Init ---------------------------------------------------------
     public init(
@@ -145,14 +144,12 @@ open class VariableBlurView: NSView {
         tint: NSColor? = nil,
         tintOpacity: CGFloat? = nil
     ) {
-        isBatchUpdating = true
         var changed = false
         if let radius, self.radius != radius { self.radius = radius; changed = true }
         if let edge, self.edge != edge { self.edge = edge; changed = true }
         if let offset, self.offset != offset { self.offset = offset; changed = true }
         if let tint, self.bluredTintColor != tint { self.bluredTintColor = tint; changed = true }
         if let tintOpacity, self.tintOpacity != tintOpacity { self.tintOpacity = tintOpacity; changed = true }
-        isBatchUpdating = false
         if changed { refresh() }
     }
 

--- a/Sources/PDVariableBlur/PDVariableBlur.swift
+++ b/Sources/PDVariableBlur/PDVariableBlur.swift
@@ -72,15 +72,14 @@ public struct VariableBlurViewRepresentable: UIViewRepresentable {
 open class VariableBlurView: UIVisualEffectView {
 
     // MARK: - Public Stored Properties
-    public var radius: CGFloat
-    public var edge: VariableBlurEdge
-    public var offset: CGFloat
-    public var bluredTintColor: UIColor?
+    private var radius: CGFloat
+    private var edge: VariableBlurEdge
+    private var offset: CGFloat
+    private var bluredTintColor: UIColor?
 
     // MARK: - Private
     private var gradientLayer: CAGradientLayer?
-    var isBatchUpdating = false
-    public var tintOpacity: CGFloat?
+    private var tintOpacity: CGFloat?
 
     // MARK: - Init
     public init(
@@ -144,14 +143,12 @@ open class VariableBlurView: UIVisualEffectView {
         tint: UIColor? = nil,
         tintOpacity: CGFloat? = nil
     ) {
-        isBatchUpdating = true
         var changed = false
         if let radius, self.radius != radius { self.radius = radius; changed = true }
         if let edge, self.edge != edge { self.edge = edge; changed = true }
         if let offset, self.offset != offset { self.offset = offset; changed = true }
         if let tint, self.bluredTintColor != tint { self.bluredTintColor = tint; changed = true }
         if let tintOpacity, self.tintOpacity != tintOpacity { self.tintOpacity = tintOpacity; changed = true }
-        isBatchUpdating = false
         if changed { refresh() }
     }
 


### PR DESCRIPTION
## Summary
- add a unified update method for updating variable blur parameters
- remove property observers that called `refresh` directly
- update `UIViewRepresentable` and `NSViewRepresentable` to use the new method

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68446610f9dc8325a8b6e135e42cf4bb