### PR TITLE
Add isEnabled flag for variableBlur

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following values can be specified with `variableBlur`:
 - `offset`: start position of the gradient, from `0` to `1`.
 - `tint`: color overlay applied to the blurred area.
 - `tintOpacity`: explicit opacity value for `tint`.
+- `isEnabled`: toggles the overlay on and off. Default is `true`.
 
 ### VariableBlurView and VariableBlurViewRepresentable
 

--- a/Sources/PDVariableBlur/VariableBlurModifier.swift
+++ b/Sources/PDVariableBlur/VariableBlurModifier.swift
@@ -37,20 +37,23 @@ public extension View {
         length: CGFloat,
         offset: CGFloat = 0,
         tint: Color? = nil,
-        tintOpacity: CGFloat? = nil
+        tintOpacity: CGFloat? = nil,
+        isEnabled: Bool = true
     ) -> some View {
         overlay(alignment: edge.overlayAlignment) {
-            VariableBlurViewRepresentable(
-                radius: radius,
-                edge: edge,
-                offset: offset,
-                tint: tint,
-                tintOpacity: tintOpacity
-            )
-            .frame(
-                width: edge.isVertical ? nil : length,
-                height: edge.isVertical ? length : nil
-            )
+            if isEnabled {
+                VariableBlurViewRepresentable(
+                    radius: radius,
+                    edge: edge,
+                    offset: offset,
+                    tint: tint,
+                    tintOpacity: tintOpacity
+                )
+                .frame(
+                    width: edge.isVertical ? nil : length,
+                    height: edge.isVertical ? length : nil
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `isEnabled` parameter to `variableBlur` modifier
- document the new option in the README

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68446f089054832586340d963bd08caf