### PR TITLE
Rename blur view classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ The following values can be specified with `variableBlur`:
 - `tintOpacity`: explicit opacity value for `tint`.
 - `isEnabled`: toggles the overlay on and off. Default is `true`.
 
-### VariableBlurView and VariableBlurViewRepresentable
+### VariableBlurEffectView and VariableBlurView
 
-`VariableBlurView` implements the variable blur using `UIVisualEffectView` or `NSView`.
-`VariableBlurViewRepresentable` exposes this view to SwiftUI, and the `variableBlur` modifier uses it internally.
+`VariableBlurEffectView` implements the variable blur using `UIVisualEffectView` or `NSView`.
+`VariableBlurView` exposes this view to SwiftUI, and the `variableBlur` modifier uses it internally.
 
 Install via Swift Package Manager and import `PDVariableBlur` in your project.
 

--- a/Sources/PDVariableBlur/PDVariableBlur+macOS.swift
+++ b/Sources/PDVariableBlur/PDVariableBlur+macOS.swift
@@ -1,5 +1,5 @@
 //
-//  VariableBlurView.swift
+//  VariableBlurEffectView.swift
 //  PDVariableBlur
 //
 //  Created by lynnswap on 2025/06/07.
@@ -10,7 +10,7 @@ import AppKit
 import CoreImage.CIFilterBuiltins
 import SwiftUI
 
-public struct VariableBlurViewRepresentable: NSViewRepresentable {
+public struct VariableBlurView: NSViewRepresentable {
     public var radius: CGFloat = 20
     public var edge: VariableBlurEdge = .top
     public var offset: CGFloat = 0
@@ -46,8 +46,8 @@ public struct VariableBlurViewRepresentable: NSViewRepresentable {
             tintOpacity: tintOpacity)
     }
 
-    public func makeNSView(context: Context) -> VariableBlurView {
-        VariableBlurView(
+    public func makeNSView(context: Context) -> VariableBlurEffectView {
+        VariableBlurEffectView(
             radius: radius,
             edge: edge,
             offset: offset,
@@ -56,7 +56,7 @@ public struct VariableBlurViewRepresentable: NSViewRepresentable {
         )
     }
 
-    public func updateNSView(_ nsView: VariableBlurView, context: Context) {
+    public func updateNSView(_ nsView: VariableBlurEffectView, context: Context) {
         nsView.update(
             radius: radius,
             edge: edge,
@@ -67,7 +67,7 @@ public struct VariableBlurViewRepresentable: NSViewRepresentable {
     }
 }
 
-open class VariableBlurView: NSView {
+open class VariableBlurEffectView: NSView {
 
     private var radius: CGFloat
     private var edge: VariableBlurEdge

--- a/Sources/PDVariableBlur/PDVariableBlur.swift
+++ b/Sources/PDVariableBlur/PDVariableBlur.swift
@@ -11,7 +11,7 @@ import CoreImage.CIFilterBuiltins
 import QuartzCore
 import SwiftUI
 
-public struct VariableBlurViewRepresentable: UIViewRepresentable {
+public struct VariableBlurView: UIViewRepresentable {
     public var radius: CGFloat = 20
     public var edge: VariableBlurEdge = .top
     public var offset: CGFloat = 0
@@ -48,8 +48,8 @@ public struct VariableBlurViewRepresentable: UIViewRepresentable {
         )
     }
     
-    public func makeUIView(context: Context) -> VariableBlurView {
-        VariableBlurView(
+    public func makeUIView(context: Context) -> VariableBlurEffectView {
+        VariableBlurEffectView(
             radius: radius,
             edge: edge,
             offset: offset,
@@ -58,7 +58,7 @@ public struct VariableBlurViewRepresentable: UIViewRepresentable {
         )
     }
 
-    public func updateUIView(_ uiView: VariableBlurView, context: Context) {
+    public func updateUIView(_ uiView: VariableBlurEffectView, context: Context) {
         uiView.update(
             radius: radius,
             edge: edge,
@@ -69,7 +69,7 @@ public struct VariableBlurViewRepresentable: UIViewRepresentable {
     }
 }
 
-open class VariableBlurView: UIVisualEffectView {
+open class VariableBlurEffectView: UIVisualEffectView {
 
     private var radius: CGFloat
     private var edge: VariableBlurEdge

--- a/Sources/PDVariableBlur/VariableBlurModifier.swift
+++ b/Sources/PDVariableBlur/VariableBlurModifier.swift
@@ -42,7 +42,7 @@ public extension View {
     ) -> some View {
         overlay(alignment: edge.overlayAlignment) {
             if isEnabled {
-                VariableBlurViewRepresentable(
+                VariableBlurView(
                     radius: radius,
                     edge: edge,
                     offset: offset,


### PR DESCRIPTION
## Summary
- rename `VariableBlurViewRepresentable` to `VariableBlurView`
- rename underlying view to `VariableBlurEffectView`
- update modifier and README

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6844f830a4948325b17f233890e21d85